### PR TITLE
fixing report collation for sonarqube

### DIFF
--- a/Global-Green-Initiative/pom.xml
+++ b/Global-Green-Initiative/pom.xml
@@ -76,6 +76,24 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version> <executions>
+				<execution>
+					<goals>
+						<goal>prepare-agent</goal>
+					</goals>
+				</execution>
+				<execution>
+					<id>report</id>
+					<phase>verify</phase> <goals>
+					<goal>report</goal>
+				</goals>
+				</execution>
+			</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This fix would allow the coverage of the unit test to be reported for pickup by sonarcloud.ie